### PR TITLE
Best practices from real apps

### DIFF
--- a/boilerplate/api/jest-puppeteer.config.js
+++ b/boilerplate/api/jest-puppeteer.config.js
@@ -2,7 +2,14 @@ module.exports = {
   launch: {
     dumpio: process.env.DEBUG === '1',
     headless: process.env.BROWSER !== '1' ? 'new' : false,
-    args: ['--disable-infobars', '--window-size=1200,800', '--disable-extensions'],
+    args: [
+      '--disable-infobars',
+      '--window-size=1200,800',
+      '--disable-extensions',
+      '--disable-setuid-sandbox',
+      '--disable-web-security',
+      '--no-sandbox',
+    ],
     defaultViewport: null,
     product: 'chrome',
     executablePath: process.env.CHROME_PATH || undefined,
@@ -13,7 +20,7 @@ module.exports = {
       command: 'BROWSER=none PORT=3000 REACT_APP_PSYCHIC_ENV=test yarn --cwd=../client start',
       host: '127.0.0.1',
       debug: process.env.DEBUG === '1',
-      launchTimeout: 20000,
+      launchTimeout: 60000,
       port: 3000,
       usedPortAction: 'kill',
       waitOnScheme: {
@@ -21,9 +28,11 @@ module.exports = {
       },
     },
     {
-      command: 'ts-node ./src/spec-server.ts',
+      command:
+        'APP_ROOT_PATH=$(pwd) TS_SAFE=1 FEATURE_SPEC_RUN=1 npx ts-node --transpile-only ./src/spec-server.ts',
       host: '127.0.0.1',
-      launchTimeout: 20000,
+      launchTimeout:
+        (process.env.LAUNCH_TIMEOUT_SECONDS && parseInt(process.env.LAUNCH_TIMEOUT_SECONDS) * 1000) || 60000,
       debug: process.env.DEBUG === '1',
       port: 7778,
       usedPortAction: 'kill',

--- a/boilerplate/api/package.json
+++ b/boilerplate/api/package.json
@@ -21,8 +21,8 @@
     "console": "APP_NAME=$npm_package_name APP_VERSION=$npm_package_version TS_SAFE=1 APP_ROOT_PATH=$(pwd) npx ts-node --project ./tsconfig.json ./src/conf/repl.ts"
   },
   "dependencies": {
-    "@rvohealth/psychic": "^0.1.57",
-    "@rvohealth/dream": "^0.1.52"
+    "@rvohealth/dream": "^0.1.70",
+    "@rvohealth/psychic": "^0.1.61"
   },
   "devDependencies": {
     "@types/expect-puppeteer": "^5.0.3",
@@ -30,6 +30,7 @@
     "@types/supertest": "^2.0.12",
     "jest-puppeteer": "^8.0.6",
     "puppeteer": "^19.9.1",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "typescript": "^5.3.3"
   }
 }

--- a/boilerplate/api/spec/features/setup/hooks.ts
+++ b/boilerplate/api/spec/features/setup/hooks.ts
@@ -2,6 +2,9 @@ import 'expect-puppeteer'
 import * as dotenv from 'dotenv'
 import { truncate } from '@rvohealth/dream/spec-helpers'
 
+process.env.APP_ROOT_PATH = process.cwd()
+process.env.TS_SAFE = '1'
+
 dotenv.config({ path: '.env.test' })
 
 beforeEach(async () => {

--- a/boilerplate/api/spec/unit/setup/hooks.ts
+++ b/boilerplate/api/spec/unit/setup/hooks.ts
@@ -3,6 +3,9 @@ import 'psychic/spec-helpers'
 import 'expect-puppeteer'
 import { truncate } from '@rvohealth/dream/spec-helpers'
 
+process.env.APP_ROOT_PATH = process.cwd()
+process.env.TS_SAFE = '1'
+
 beforeEach(async () => {
   await truncate()
 })


### PR DESCRIPTION
TS_SAFE and APP_ROOT_PATH necessary for feature spec runs since jest runs in different process than the server