### PR TITLE
fix(boilerplate): remove escape sequences from JSON log output

### DIFF
--- a/boilerplate/api/src/conf/app.ts
+++ b/boilerplate/api/src/conf/app.ts
@@ -94,7 +94,7 @@ export default async (psy: PsychicApplication) => {
       app.use(
         expressWinston.logger({
           transports: [new winston.transports.Console()],
-          format: winston.format.combine(winston.format.colorize(), winston.format.json()),
+          format: winston.format.combine(winston.format.json()),
           meta: true, // optional: control whether you want to log the meta data about the request (default to true)
           msg: 'HTTP {{req.method}} {{req.url}}', // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
           expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true

--- a/spec/fixtures/expected-files/app/no-workers.ts
+++ b/spec/fixtures/expected-files/app/no-workers.ts
@@ -94,7 +94,7 @@ export default async (psy: PsychicApplication) => {
       app.use(
         expressWinston.logger({
           transports: [new winston.transports.Console()],
-          format: winston.format.combine(winston.format.colorize(), winston.format.json()),
+          format: winston.format.combine(winston.format.json()),
           meta: true, // optional: control whether you want to log the meta data about the request (default to true)
           msg: 'HTTP {{req.method}} {{req.url}}', // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
           expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true

--- a/spec/fixtures/expected-files/app/yes-workers.ts
+++ b/spec/fixtures/expected-files/app/yes-workers.ts
@@ -95,7 +95,7 @@ export default async (psy: PsychicApplication) => {
       app.use(
         expressWinston.logger({
           transports: [new winston.transports.Console()],
-          format: winston.format.combine(winston.format.colorize(), winston.format.json()),
+          format: winston.format.combine(winston.format.json()),
           meta: true, // optional: control whether you want to log the meta data about the request (default to true)
           msg: 'HTTP {{req.method}} {{req.url}}', // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
           expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true


### PR DESCRIPTION
using `colorize()` and `json()` produces output like this. Not impossible to read, of course, but not really ideal.

``` json
{"level":"\u001b[32minfo\u001b[39m", "message":"GET /helo 200 4ms"}
```