### PR TITLE
Raise boilerplate @rvoh/psychic floor to ^3.4.2 (shutdown-hang fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.2
+
+- Boilerplate `api/package.json` raises its `@rvoh/psychic` floor from `^3.0.5` to `^3.4.2`. psychic@3.4.2 fixes a `PsychicServer.stop()` graceful-shutdown hang: `stop()` now force-closes lingering keep-alive sockets before tearing down the database pool. The scaffolded feature-spec `afterAll` (`await server.stop()`) and the SIGTERM drain path both depend on this — without the floor, a lockfile resolving to a pre-3.4.2 psychic would hang the generated app's `pnpm fspec` teardown for the full hook timeout whenever the persistent Puppeteer page has in-flight requests.
+
 ## 3.4.1
 
 Refines the R-027 Postgres TLS migration shipped in 3.4.0. Pairs with dream@2.10.0, which narrows `SingleDbCredential.ssl` to `TlsConnectionOptions | false` and throws when the directive is omitted.

--- a/boilerplate/api/package.json
+++ b/boilerplate/api/package.json
@@ -31,7 +31,7 @@
     "@koa/etag": "^5.0.2",
     "@koa/router": "^15.3.1",
     "@rvoh/dream": "^2.10.0",
-    "@rvoh/psychic": "^3.0.5",
+    "@rvoh/psychic": "^3.4.2",
     "@rvoh/psychic-websockets": "^3.1.0",
     "@rvoh/psychic-workers": "^2.3.0",
     "@socket.io/redis-adapter": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/create-psychic",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "creates a new psychic app",
   "author": "RVO Health",
   "repository": {


### PR DESCRIPTION
## Summary

Bumps the boilerplate `api/package.json` `@rvoh/psychic` floor from `^3.0.5` to `^3.4.2`.

psychic@3.4.2 (rvohealth/psychic#503) fixes a `PsychicServer.stop()` graceful-shutdown hang — `stop()` now force-closes lingering keep-alive sockets before tearing down the DB pool. The scaffolded feature-spec `afterAll` (`await server.stop()`) and the production SIGTERM drain both depend on this. Without the floor, a generated app whose lockfile resolves `@rvoh/psychic` to a pre-3.4.2 version hangs `pnpm fspec` teardown for the full hook timeout whenever the persistent Puppeteer page has in-flight requests.

Patch release `3.4.2` (no generator behavior change; boilerplate dependency floor only).

## Test plan

- [x] `pnpm lint` — green (src unchanged; change is template package.json + version + changelog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)