### PR TITLE
Make pnpm dependency builds non-fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.4.3
+
+- Generated pnpm apps now set `strictDepBuilds: false` in `pnpm-workspace.yaml`. Dependency build scripts remain blocked by default, but newly introduced optional native package build scripts no longer make app creation fail.
+- Added pnpm scaffold regression coverage for the generated `pnpm-workspace.yaml` build approval policy.
+
 ## 3.4.2
 
 - Boilerplate `api/spec/features/setup/hooks.ts` now calls `resetBrowserState()` (from `@rvoh/psychic-spec-helpers` ≥ 3.1.0) in `afterEach`. The feature-spec browser is shared across spec files, so without per-spec cleanup `localStorage`/cookies leak between specs (incomplete isolation) and an in-flight request can keep a pooled DB client checked out across `server.stop()`. `resetBrowserState()` clears storage + cookies and navigates to `about:blank`, fixing both. The connection-lifecycle robustness itself is handled upstream in `@rvoh/dream` (bounded pool drain); this keeps per-spec teardown fast, clean, and properly isolated.

--- a/boilerplate/api/pnpm-workspace.yaml
+++ b/boilerplate/api/pnpm-workspace.yaml
@@ -1,9 +1,7 @@
+strictDepBuilds: false
+
 overrides:
   path-to-regexp: '>=8.4.0'
-
-allowBuilds:
-  esbuild: true
-  puppeteer: true
 
 minimumReleaseAgeExclude:
   - '@rvoh/dream'

--- a/boilerplate/api/spec/unit/helpers/authentication.ts
+++ b/boilerplate/api/spec/unit/helpers/authentication.ts
@@ -21,7 +21,7 @@ export type RequestQuery<HttpMethod extends 'get' | 'post' | 'patch' | 'delete',
 >
 
 // eslint-disable-next-line @typescript-eslint/require-await
-async function userJwt(user: User): Promise<string> {
+async function userBearerToken(user: User): Promise<string> {
   /**
    * The current authentication scheme is only for early development.
    * Replace with a production grade authentication scheme.
@@ -33,7 +33,7 @@ async function userJwt(user: User): Promise<string> {
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
-async function adminUserJwt(adminUser: Dream): Promise<string> {
+async function adminUserBearerToken(adminUser: Dream): Promise<string> {
   /**
    * The current authentication scheme is only for early development.
    * Replace with a production grade authentication scheme.
@@ -45,7 +45,7 @@ async function adminUserJwt(adminUser: Dream): Promise<string> {
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
-async function internalUserJwt(internalUser: Dream): Promise<string> {
+async function internalUserBearerToken(internalUser: Dream): Promise<string> {
   /**
    * The current authentication scheme is only for early development.
    * Replace with a production grade authentication scheme.
@@ -60,14 +60,14 @@ export async function session(user: Dream) {
   const request = new OpenapiSpecRequest<OpenapiPaths>()
   await request.init(PsychicServer)
 
-  /** if using JWT authentication*/
+  /** if using bearer-token authentication*/
   let bearerToken: string
   if (user instanceof User) {
-    bearerToken = await userJwt(user)
+    bearerToken = await userBearerToken(user)
   } else if (user.sanitizedConstructorName === 'InternalUser') {
-    bearerToken = await internalUserJwt(user)
+    bearerToken = await internalUserBearerToken(user)
   } else {
-    bearerToken = await adminUserJwt(user)
+    bearerToken = await adminUserBearerToken(user)
   }
   return request.setDefaultHeaders({ Authorization: `Bearer ${bearerToken}` })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/create-psychic",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "creates a new psychic app",
   "author": "RVO Health",
   "repository": {

--- a/spec/unit/initPsychicApp/templates/nextjs/pnpm/basic.spec.ts
+++ b/spec/unit/initPsychicApp/templates/nextjs/pnpm/basic.spec.ts
@@ -2,6 +2,7 @@ import sspawn from '../../../../../../src/helpers/sspawn.js'
 import expectNoWebsockets from '../../../../../helpers/assertions/expectNoWebsockets.js'
 import expectNoWorkers from '../../../../../helpers/assertions/expectNoWorkers.js'
 import expectFile from '../../../../../helpers/expectFile.js'
+import expectFileToContain from '../../../../../helpers/expectFileToContain.js'
 import temporarilyDisableEslintForNextjsBuild from '../../../../../helpers/init/temporarilyDisableEslintForNextjsBuild.js'
 import initPsychicAppDefaults from '../../../../../helpers/initPsychicAppDefaults.js'
 import initSpecPsychicApp from '../../../../../helpers/initSpecPsychicApp.js'
@@ -20,6 +21,7 @@ describe('initPsychicApp with --template=nextjs flag', () => {
 
     await expectFile('howyadoin/src/instrumentation.mts')
     await expectFile('howyadoin/src/instrumentation-node.mts')
+    await expectFileToContain('howyadoin/pnpm-workspace.yaml', 'strictDepBuilds: false')
 
     // swap out the default page.tsx file for one that calls to maybeInitializePsychicApp,
     // which will cause build to fail if anything crashes during psychic initialization.

--- a/spec/unit/newPsychicApp/package-managers/pnpm/no-client.spec.ts
+++ b/spec/unit/newPsychicApp/package-managers/pnpm/no-client.spec.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs'
 import sspawn from '../../../../../src/helpers/sspawn.js'
 import expectFile from '../../../../helpers/expectFile.js'
+import expectFileToContain from '../../../../helpers/expectFileToContain.js'
 import expectToMatchFixture from '../../../../helpers/expectToMatchFixture.js'
 import newSpecPsychicApp from '../../../../helpers/newSpecPsychicApp.js'
 
@@ -19,6 +20,7 @@ describe('newPsychicApp with no client', () => {
     })
 
     await expectFile('./howyadoin/pnpm-lock.yaml')
+    await expectFileToContain('./howyadoin/pnpm-workspace.yaml', 'strictDepBuilds: false')
     await expectFile('./howyadoin/docker-compose.yml')
     await expectFile('./howyadoin/Dockerfile.dev')
 

--- a/spec/unit/newPsychicApp/package-managers/pnpm/react.spec.ts
+++ b/spec/unit/newPsychicApp/package-managers/pnpm/react.spec.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs'
 import sspawn from '../../../../../src/helpers/sspawn.js'
 import expectFile from '../../../../helpers/expectFile.js'
+import expectFileToContain from '../../../../helpers/expectFileToContain.js'
 import expectToMatchFixture from '../../../../helpers/expectToMatchFixture.js'
 import newSpecPsychicApp from '../../../../helpers/newSpecPsychicApp.js'
 
@@ -21,6 +22,7 @@ describe('newPsychicApp with react client', () => {
     await expectFile('./howyadoin/api/pnpm-lock.yaml')
     await expectFile('./howyadoin/api/Dockerfile.dev')
     await expectFile('./howyadoin/client/Dockerfile.dev')
+    await expectFileToContain('./howyadoin/client/pnpm-workspace.yaml', 'strictDepBuilds: false')
 
     await expectToMatchFixture(
       'expected-files/docker-compose/pnpm/client-basic.yml',

--- a/src/helpers/addClientApp.ts
+++ b/src/helpers/addClientApp.ts
@@ -151,11 +151,11 @@ export default async function addClientApp({
   }
 
   // Prevent pnpm from traversing up and merging with a parent workspace (e.g. create-psychic's own pnpm-workspace.yaml during specs).
-  // Also pre-approve build scripts that pnpm 11 blocks by default.
+  // Keep dependency build scripts blocked by default without failing when optional native packages request them.
   if (options.packageManager === 'pnpm') {
     fs.writeFileSync(
       path.join(apiRoot, '..', clientRootFolderName, 'pnpm-workspace.yaml'),
-      pnpmClientWorkspaceYaml(client),
+      'strictDepBuilds: false\n',
     )
   }
 
@@ -209,16 +209,6 @@ function addFspecBuildDirToGitignore(gitignorePath: string, dirName: string) {
     if (!contents.includes(dirName)) {
       fs.writeFileSync(gitignorePath, `${contents}\n\n# fspec build directory\n${dirName}\n`)
     }
-  }
-}
-
-function pnpmClientWorkspaceYaml(client: (typeof cliClientAppTypes)[number]) {
-  switch (client) {
-    case 'nextjs':
-    case 'nuxt':
-      return 'allowBuilds:\n  esbuild: true\n  sharp: true\n  unrs-resolver: true\n'
-    default:
-      return 'allowBuilds:\n  esbuild: true\n'
   }
 }
 

--- a/src/helpers/init/copyInitApiBoilerplate.ts
+++ b/src/helpers/init/copyInitApiBoilerplate.ts
@@ -212,7 +212,7 @@ export default async function copyInitApiBoilerplate(appName: string, options: I
   }
 
   if (options.packageManager === 'pnpm') {
-    writeFileSync('pnpm-workspace.yaml', pnpmWorkspaceYaml(options))
+    writeFileSync('pnpm-workspace.yaml', pnpmWorkspaceYaml())
   }
 
   writeFileSync(
@@ -225,10 +225,12 @@ export default async function copyInitApiBoilerplate(appName: string, options: I
   )
 }
 
-function pnpmWorkspaceYaml(options: InitPsychicAppCliOptions) {
+function pnpmWorkspaceYaml() {
   // pnpm 11 introduced minimumReleaseAge (default: 1440 min = 24h), which prevents
   // installing packages published less than 24h ago. @rvoh/* packages are excluded
   // so that freshly-published releases are always available to generated apps.
+  // Dependency build scripts stay blocked by default, but unreviewed optional native
+  // package build scripts should not make the scaffold unusable.
   const rvohExcludes =
     'minimumReleaseAgeExclude:\n' +
     "  - '@rvoh/dream'\n" +
@@ -238,16 +240,7 @@ function pnpmWorkspaceYaml(options: InitPsychicAppCliOptions) {
     "  - '@rvoh/psychic-workers'\n" +
     "  - '@rvoh/psychic-websockets'\n"
 
-  if (options.template === 'nextjs') {
-    return (
-      'allowBuilds:\n  esbuild: true\n  puppeteer: true\n  sharp: true\n  unrs-resolver: true\n' +
-      rvohExcludes
-    )
-  }
-  if (options.dreamOnly) {
-    return 'allowBuilds:\n  esbuild: true\n' + rvohExcludes
-  }
-  return 'allowBuilds:\n  esbuild: true\n  puppeteer: true\n' + rvohExcludes
+  return 'strictDepBuilds: false\n\n' + rvohExcludes
 }
 
 function copyRecursiveSync(path: string, dest: string, importExtension: (typeof importExtensions)[number]) {


### PR DESCRIPTION
## Summary
- set generated pnpm workspaces to strictDepBuilds: false so dependency build scripts stay blocked but newly introduced optional native build scripts do not fail scaffolding
- remove generated pnpm allowBuilds entries for API/init/client scaffold paths
- bump package version to 3.4.3 and update CHANGELOG
- add pnpm scaffold regression coverage for generated API, init, and client pnpm-workspace.yaml files

## Verification
- DEBUG=1 pnpm spec spec/unit/newPsychicApp/package-managers/pnpm/no-client.spec.ts spec/unit/newPsychicApp/package-managers/pnpm/react.spec.ts spec/unit/initPsychicApp/templates/nextjs/pnpm/basic.spec.ts
- DEBUG=1 pnpm spec